### PR TITLE
Dockerize the Rust version and tweak for production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +570,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -767,6 +846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1275,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "askama",
+ "env_logger",
  "regex",
  "reqwest",
  "serde",
@@ -1953,6 +2045,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 actix-web = "4.9.0"
 askama = "0.12.1"
+env_logger = "0.11.6"
 regex = "1.11.1"
 reqwest = { version = "0.12.12", features = ["json"] }
 serde = { version = "1.0.218", features = ["derive"] }

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.85.0-alpine3.21 AS build
 RUN apk add --no-cache build-base openssl-dev
-ENV RUSTFLAGS="-Clink-self-contained=off -Ctarget-feature=-crt-static"
+ENV RUSTFLAGS="-Ctarget-feature=-crt-static"
 RUN cargo install --locked cargo-auditable@0.6.6
 WORKDIR /app
 ADD . .

--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,14 @@
-FROM python:3.10-alpine3.14
-WORKDIR /srv
-COPY . /srv
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
-ENV FLASK_APP=app
-CMD ["python","app.py"]
+FROM rust:1.85.0-alpine3.21 AS build
+RUN apk add --no-cache build-base openssl-dev
+ENV RUSTFLAGS="-Clink-self-contained=off -Ctarget-feature=-crt-static"
+RUN cargo install --locked cargo-auditable@0.6.6
+WORKDIR /app
+ADD . .
+RUN cargo auditable build --release
+
+FROM alpine:3.21.3
+RUN apk add --no-cache libgcc
+RUN adduser -D app
+USER app
+COPY --from=build /app/target/release/nvda_zip /usr/local/bin/
+CMD ["nvda_zip"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use actix_web::{App, HttpResponse, HttpServer, Responder, web};
+use actix_web::{App, HttpResponse, HttpServer, Responder, middleware, web};
 use askama::Template;
 use regex::Regex;
 use serde::Serialize;
@@ -123,8 +123,11 @@ async fn not_found() -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
     HttpServer::new(|| {
         App::new()
+            .wrap(middleware::Logger::default())
             .route("/", web::get().to(index))
             .route("/stable.json", web::get().to(stable_json))
             .route("/xp", web::get().to(xp))
@@ -135,7 +138,7 @@ async fn main() -> std::io::Result<()> {
             .route("/beta.json", web::get().to(beta_json))
             .default_service(web::to(not_found))
     })
-    .bind("0.0.0.0:8080")?
+    .bind_auto_h2c(("0.0.0.0", 5000))?
     .run()
     .await
 }


### PR DESCRIPTION
* Builds a reasonably small Alpine-based image.
* Disables the normal Rust musl toolchain behavior of building a statically linked binary using the self-contained libc included with that Rust toolchain, so we can dynamically link with Alpine's versions of musl and OpenSSL for greater auditability.
* Uses cargo-auditable to embed information about Rust dependencies in the binary. Container vulnerability scanners can look at this info.
* Changes the port from 8080 to 5000 to match the existing docker-compose deployment.
* Enables logging, following the pattern in the actix-web examples.
* Enables automatic detection of h2c (HTTP/2 cleartext) connections, so the reverse proxy can use that. If this is ever deployed on infrastructure using a reverse proxy with HTTP/2 enabled, then the connection from the reverse proxy to the app should really also be HTTP/2, to avoid [certain vulnerabilities](https://portswigger.net/research/http2). HTTP/1.1 is still supported though.