### PR TITLE
Cache results and throttle refreshes to one at a time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12.12", default-features = false, features = ["http2", "rustls-tls-webpki-roots"] }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.140"
+tokio = { version = "1.43.0", default-features = false, features = ["rt", "sync"] }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
This should eliminate any chance of this app being used to DoS NV Access. The results are now cached for 30 seconds, and the app can only make one request at a time to the NVDA download server. That request is made in its own tokio task which runs to completion even if the originating request is canceled, to make sure that someone can't DoS NV Access by repeatedly making and canceling their own requests. And we have a single long-lived HTTP client, so the connection to NV Access can be kept open (as long as the NV Access server allows) and potentially reused.